### PR TITLE
Fix bugs, security issues, and optimize cashback cleanup

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,7 +4,6 @@ import { Request, Response } from 'express';
 import { GoogleAuthGuard } from './guards/google.guard';
 import { User } from '../user/schemas/user.schema';
 import { YandexAuthGuard } from './guards/yandex.guard';
-import passport from 'passport';
 
 @Controller('auth')
 export class AuthController {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Response } from 'express';
 import { User } from '../user/schemas/user.schema';
@@ -7,6 +8,7 @@ import { User } from '../user/schemas/user.schema';
 export class AuthService {
     constructor(
         private jwtService: JwtService,
+        private configService: ConfigService,
     ) {}
 
     async login(
@@ -18,9 +20,10 @@ export class AuthService {
                 throw new Error('Authentication failed');
             }
             const jwtToken = this.jwtService.sign({ userId: user._id });
+            const clientUrl = this.configService.get<string>('CLIENT_URL');
             const script = `
                 <script>
-                    window.opener.postMessage({ token: '${jwtToken}' }, '*');
+                    window.opener.postMessage({ token: '${jwtToken}' }, '${clientUrl}');
                     window.close();
                 </script>
             `;

--- a/src/auth/strategies/google.strategy.ts
+++ b/src/auth/strategies/google.strategy.ts
@@ -30,7 +30,6 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
                 name: displayName,
                 picture: photos[0].value,
             });
-            await user.save();
         }
 
         return done(null, user);

--- a/src/auth/strategies/yandex.strategy.ts
+++ b/src/auth/strategies/yandex.strategy.ts
@@ -31,7 +31,6 @@ export class YandexStrategy extends PassportStrategy(Strategy, 'yandex') {
                 name: displayName,
                 picture: photos[0].value,
             });
-            await user.save();
         }
 
         return done(null, user);

--- a/src/card/card.service.ts
+++ b/src/card/card.service.ts
@@ -43,7 +43,7 @@ export class CardService {
         name: string,
         bank: EBank,
     ): Promise<Card> {
-        const result = this.cardModel.findOneAndDelete({ userId, name, bank }).exec();
+        const result = await this.cardModel.findOneAndDelete({ userId, name, bank }).exec();
         await this.cashbackService.findAllAndUpdate({ userId, card: { name, bank } }, { card: null });
         return result;
     }

--- a/src/card/createCardDto.ts
+++ b/src/card/createCardDto.ts
@@ -1,14 +1,11 @@
 import { IsString } from 'class-validator';
 import { EBank, TUserId } from 'cashback-check-types';
-import { Prop } from '@nestjs/mongoose';
 
 export class CreateCardDto {
     @IsString()
-    @Prop({ required: true })
     readonly bank: EBank;
 
     @IsString()
-    @Prop({ required: true })
     readonly name: string;
 
     @IsString()

--- a/src/cashback/cashback.service.ts
+++ b/src/cashback/cashback.service.ts
@@ -6,7 +6,6 @@ import { CreateCashbackDto } from './createCashbackDto';
 import { TCashbackId, TUserId } from 'cashback-check-types';
 import { getCashbackIcon } from './utils/getCashbackIcon';
 import { getCashbackColor } from './utils/getCashbackColor';
-import { getIsCashbackExpired } from './utils/getIsCashbackExpired';
 
 @Injectable()
 export class CashbackService {
@@ -25,19 +24,14 @@ export class CashbackService {
         return createdCashback.save();
     }
 
-    async removeOldCashbacks(userId: TUserId) {
-        const cashbacks = await this.cashbackModel
-            .find({ userId })
-            .exec();
-        for (const cashback of cashbacks) {
-            if (getIsCashbackExpired(cashback.timestamp)) {
-                await this.remove(cashback.id);
-            }
-        }
-    }
-
     async findAll(userId: TUserId): Promise<Cashback[]> {
-        await this.removeOldCashbacks(userId);
+        const currentMonthStart = new Date();
+        currentMonthStart.setDate(1);
+        currentMonthStart.setHours(0, 0, 0, 0);
+        await this.cashbackModel.deleteMany({
+            userId,
+            timestamp: { $lt: currentMonthStart.getTime() },
+        }).exec();
         return await this.cashbackModel.find({ userId }).exec();
     }
 

--- a/src/cashback/createCashbackDto.ts
+++ b/src/cashback/createCashbackDto.ts
@@ -1,18 +1,15 @@
-import { IsNumber, IsString } from 'class-validator';
-import { EBank, ECashbackColor, ICard } from 'cashback-check-types';
-import { TUserId } from 'cashback-check-types';
-import { Prop } from '@nestjs/mongoose';
+import { IsNumber, IsObject, IsOptional, IsString } from 'class-validator';
+import { EBank, ECashbackColor, ICard, TUserId } from 'cashback-check-types';
 
 export class CreateCashbackDto {
     @IsString()
-    @Prop({ required: true })
     readonly bank: EBank;
 
-    @IsString()
+    @IsOptional()
+    @IsObject()
     readonly card: ICard;
 
     @IsNumber()
-    @Prop({ required: true })
     cardOrderNumber: number;
 
     @IsString()
@@ -22,23 +19,18 @@ export class CreateCashbackDto {
     readonly icon: string;
 
     @IsString()
-    @Prop({ required: true })
     readonly name: string;
 
     @IsNumber()
-    @Prop({ required: true })
     readonly percentage: number;
 
     @IsNumber()
-    @Prop({ required: true })
     orderNumber: number;
 
     @IsNumber()
-    @Prop({ required: true })
     bankOrderNumber: number;
 
     @IsNumber()
-    @Prop({ required: true })
     readonly timestamp: number;
 
     @IsString()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import * as process from 'node:process';
 
@@ -8,6 +9,7 @@ async function bootstrap() {
         origin: process.env.CLIENT_URL,
         credentials: true,
     });
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
     await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/user/updateUserDto.ts
+++ b/src/user/updateUserDto.ts
@@ -16,8 +16,8 @@ export class UpdateUserDto {
 
 export class SettingsDto {
     @IsBoolean()
-    isHideStories?: string;
+    isHideStories?: boolean;
 
     @IsBoolean()
-    isHideAddCard?: string;
+    isHideAddCard?: boolean;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,7 @@
-import { Body, Controller, Delete, Get, Put, Req, Res, UseGuards } from '@nestjs/common'
+import { Body, Controller, Delete, Get, Put, Req, UnauthorizedException, UseGuards } from '@nestjs/common'
 import { UserService } from './user.service'
 import { JwtAuthGuard } from '../auth/guards/jwt.guard';
-import { Request, Response } from 'express';
+import { Request } from 'express';
 import { getTransformedUser } from './utils/getTransformedUser';
 import { UpdateUserDto } from './updateUserDto';
 
@@ -11,29 +11,28 @@ export class UserController {
     constructor(private readonly userService: UserService) {}
 
     @Get('me')
-    async getProfile(@Req() req: Request, @Res() res: Response) {
+    async getProfile(@Req() req: Request) {
         //@ts-ignore
         const userId = req.user?.userId;
         if (!userId) {
-            return { error: 'Not authenticated' };
+            throw new UnauthorizedException();
         }
         const user = await this.userService.findById(userId);
-        return res.json(getTransformedUser(user));
+        return getTransformedUser(user);
     }
 
     @Put('me')
     async updateProfile(
         @Req() req: Request,
-        @Res() res: Response,
-        @Body() updateUserDto: Partial<UpdateUserDto>,
+        @Body() updateUserDto: UpdateUserDto,
     ) {
         //@ts-ignore
         const userId = req.user?.userId;
         if (!userId) {
-            return { error: 'Not authenticated' };
+            throw new UnauthorizedException();
         }
         const user = await this.userService.update(userId, updateUserDto);
-        return res.json(getTransformedUser(user));
+        return getTransformedUser(user);
     }
 
     @Delete('me')
@@ -41,7 +40,7 @@ export class UserController {
         //@ts-ignore
         const userId = req.user?.userId;
         if (!userId) {
-            return { error: 'Not authenticated' };
+            throw new UnauthorizedException();
         }
         return await this.userService.delete(userId);
     }


### PR DESCRIPTION
## Summary

- **Fix missing `await`** in `CardService.remove()` — was returning an unresolved Promise instead of the deleted card document
- **Fix `SettingsDto` types** — `isHideStories`/`isHideAddCard` were typed as `string` but decorated with `@IsBoolean()`
- **Remove redundant double `.save()`** in Google & Yandex OAuth strategies — `UserService.create()` already saves
- **Add global `ValidationPipe`** in `main.ts` — class-validator decorators on DTOs were never actually executing
- **Fix `UserController` error responses** — returning plain objects with `@Res()` decorator would hang the request; now throws `UnauthorizedException` and removes unnecessary `@Res()` usage
- **Security: restrict `postMessage` origin** — changed from `'*'` to `CLIENT_URL` to prevent token leakage to malicious windows
- **Optimize expired cashback cleanup** — replaced N+1 pattern (fetch all → delete one-by-one) with a single `deleteMany` query
- **Remove unused `passport` import** from auth controller
- **Remove misplaced `@Prop()` decorators** from DTOs (Mongoose decorator, not applicable to DTOs)
- **Fix `card` field validation** in `CreateCashbackDto` — was `@IsString()` on an object field, now `@IsObject()`

## Test plan

- [ ] Verify OAuth login flow works (Google & Yandex) — user creation and JWT token delivery
- [ ] Verify `postMessage` sends token only to the configured `CLIENT_URL` origin
- [ ] Test card delete returns the correct deleted card document (was broken by missing await)
- [ ] Test creating/updating cashbacks with DTO validation enabled
- [ ] Verify expired cashbacks are cleaned up on `GET /cashback`
- [ ] Run `yarn test` and `yarn test:e2e`

https://claude.ai/code/session_01Bv4nev8mKxAb9daudTnkHz