### PR TITLE
Fix settings endpoint rejecting requests due to missing @IsOptional()

### DIFF
--- a/src/user/updateUserDto.ts
+++ b/src/user/updateUserDto.ts
@@ -1,23 +1,28 @@
-import { IsArray, IsBoolean, IsObject, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { ECashbacksView, ISettings } from 'cashback-check-types';
 import { Type } from 'class-transformer';
 
 export class UpdateUserDto {
+    @IsOptional()
     @IsString()
     readonly cashbacksView?: ECashbacksView;
 
+    @IsOptional()
     @IsArray()
     readonly seenStories?: number[];
 
+    @IsOptional()
     @ValidateNested()
     @Type(() => SettingsDto)
     readonly settings?: ISettings;
 }
 
 export class SettingsDto {
+    @IsOptional()
     @IsBoolean()
     isHideStories?: boolean;
 
+    @IsOptional()
     @IsBoolean()
     isHideAddCard?: boolean;
 }


### PR DESCRIPTION
The previous PR added a global ValidationPipe but did not add @IsOptional()
to the optional fields in UpdateUserDto and SettingsDto. class-validator
treats fields without @IsOptional() as required, so any PUT /users/me request
that omits cashbacksView or seenStories (e.g. a settings-only update) would
fail with 400. Same issue for individual settings fields in SettingsDto.

https://claude.ai/code/session_016NeZvDHk1AHen5DZek4VgY